### PR TITLE
Add channel reload functionality

### DIFF
--- a/CarbonChat/src/main/java/net/draycia/carbon/channels/ChannelRegistry.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/channels/ChannelRegistry.java
@@ -52,4 +52,9 @@ public class ChannelRegistry implements Registry<ChatChannel> {
         return registry.get(key);
     }
 
+    @Override
+    public void clearAll() {
+        registry.clear();
+    }
+
 }

--- a/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
@@ -20,6 +20,8 @@ public class ChatReloadCommand extends BaseCommand {
     public void baseCommand(CommandSender sender) {
         carbonChat.reloadConfig();
 
+        carbonChat.getChannelManager().reload();
+
         Component message = carbonChat.getAdventureManager().processMessage(carbonChat.getConfig().getString("language.reloaded"),
                 "br", "\n");
 

--- a/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
@@ -20,6 +20,8 @@ public class ChatReloadCommand extends BaseCommand {
     public void baseCommand(CommandSender sender) {
         carbonChat.reloadConfig();
 
+        carbonChat.getCommandManager().reloadCommands();
+
         carbonChat.getChannelManager().reload();
 
         Component message = carbonChat.getAdventureManager().processMessage(carbonChat.getConfig().getString("language.reloaded"),

--- a/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
@@ -26,6 +26,9 @@ public class ChatReloadCommand extends BaseCommand {
                 "br", "\n");
 
         carbonChat.getAdventureManager().getAudiences().audience(sender).sendMessage(message);
+
+        // TODO: Ensure the command list is updated when reloading.
+        // If new channels are added, their commands should appear to players.
     }
 
 }

--- a/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/commands/ChatReloadCommand.java
@@ -20,8 +20,6 @@ public class ChatReloadCommand extends BaseCommand {
     public void baseCommand(CommandSender sender) {
         carbonChat.reloadConfig();
 
-        carbonChat.getCommandManager().reloadCommands();
-
         carbonChat.getChannelManager().reload();
 
         Component message = carbonChat.getAdventureManager().processMessage(carbonChat.getConfig().getString("language.reloaded"),

--- a/CarbonChat/src/main/java/net/draycia/carbon/managers/ChannelManager.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/managers/ChannelManager.java
@@ -21,17 +21,7 @@ public class ChannelManager {
         this.carbonChat = carbonChat;
         this.registry = new ChannelRegistry(carbonChat);
 
-        for (String key : carbonChat.getConfig().getConfigurationSection("channels").getKeys(false)) {
-            ConfigurationSection section = carbonChat.getConfig().getConfigurationSection("channels").getConfigurationSection(key);
-
-            ChatChannel channel = loadChannel(key, section);
-
-            if (channel != null) {
-                if (registerChannel(channel)) {
-                    carbonChat.getLogger().info("Registering channel: " + channel.getName());
-                }
-            }
-        }
+        reload();
     }
 
     public ChatChannel loadChannel(String key, ConfigurationSection section) {
@@ -87,6 +77,22 @@ public class ChannelManager {
         }
 
         return channel;
+    }
+
+    public void reload() {
+        registry.clearAll();
+
+        for (String key : carbonChat.getConfig().getConfigurationSection("channels").getKeys(false)) {
+            ConfigurationSection section = carbonChat.getConfig().getConfigurationSection("channels").getConfigurationSection(key);
+
+            ChatChannel channel = loadChannel(key, section);
+
+            if (channel != null) {
+                if (registerChannel(channel)) {
+                    carbonChat.getLogger().info("Registering channel: " + channel.getName());
+                }
+            }
+        }
     }
 
 }

--- a/CarbonChat/src/main/java/net/draycia/carbon/managers/CommandManager.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/managers/CommandManager.java
@@ -78,20 +78,21 @@ public class CommandManager {
             }
         });
 
-        setupCommands(commandManager);
+        reloadCommands();
     }
 
-    private void setupCommands(BukkitCommandManager manager) {
-        manager.registerCommand(new ToggleCommand());
-        manager.registerCommand(new ChannelCommand());
-        manager.registerCommand(new IgnoreCommand());
-        manager.registerCommand(new ChatReloadCommand());
-        manager.registerCommand(new MeCommand());
-        manager.registerCommand(new MessageCommand());
-        manager.registerCommand(new NicknameCommand());
-        manager.registerCommand(new ReplyCommand());
-        manager.registerCommand(new SetColorCommand());
-        manager.registerCommand(new SpyChannelCommand());
+    public void reloadCommands() {
+        this.commandManager.unregisterCommands();
+        this.commandManager.registerCommand(new ToggleCommand());
+        this.commandManager.registerCommand(new ChannelCommand());
+        this.commandManager.registerCommand(new IgnoreCommand());
+        this.commandManager.registerCommand(new ChatReloadCommand());
+        this.commandManager.registerCommand(new MeCommand());
+        this.commandManager.registerCommand(new MessageCommand());
+        this.commandManager.registerCommand(new NicknameCommand());
+        this.commandManager.registerCommand(new ReplyCommand());
+        this.commandManager.registerCommand(new SetColorCommand());
+        this.commandManager.registerCommand(new SpyChannelCommand());
     }
 
     public co.aikar.commands.CommandManager getCommandManager() {

--- a/CarbonChat/src/main/java/net/draycia/carbon/managers/CommandManager.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/managers/CommandManager.java
@@ -82,7 +82,6 @@ public class CommandManager {
     }
 
     public void reloadCommands() {
-        this.commandManager.unregisterCommands();
         this.commandManager.registerCommand(new ToggleCommand());
         this.commandManager.registerCommand(new ChannelCommand());
         this.commandManager.registerCommand(new IgnoreCommand());
@@ -95,7 +94,7 @@ public class CommandManager {
         this.commandManager.registerCommand(new SpyChannelCommand());
     }
 
-    public co.aikar.commands.CommandManager getCommandManager() {
+    public BukkitCommandManager getCommandManager() {
         return commandManager;
     }
 

--- a/CarbonChat/src/main/java/net/draycia/carbon/util/Registry.java
+++ b/CarbonChat/src/main/java/net/draycia/carbon/util/Registry.java
@@ -30,4 +30,9 @@ public interface Registry<T> {
     @Nullable
     T get(String key);
 
+    /**
+     * Clears all registered entries from the registry
+     */
+    void clearAll();
+
 }

--- a/CarbonChatModeration/src/main/java/net/draycia/carbonmoderation/CarbonChatModeration.java
+++ b/CarbonChatModeration/src/main/java/net/draycia/carbonmoderation/CarbonChatModeration.java
@@ -1,6 +1,6 @@
 package net.draycia.carbonmoderation;
 
-import net.draycia.carbon.libs.co.aikar.commands.CommandManager;
+import net.draycia.carbon.libs.co.aikar.commands.BukkitCommandManager;
 import net.draycia.carbon.CarbonChat;
 import net.draycia.carbonmoderation.commands.ClearChatCommand;
 import net.draycia.carbonmoderation.commands.MuteCommand;
@@ -27,7 +27,7 @@ public final class CarbonChatModeration extends JavaPlugin {
     }
 
     private void registerCommands() {
-        CommandManager commandManager = carbonChat.getCommandManager().getCommandManager();
+        BukkitCommandManager commandManager = carbonChat.getCommandManager().getCommandManager();
 
         commandManager.registerCommand(new ClearChatCommand(this));
         commandManager.registerCommand(new MuteCommand(this));


### PR DESCRIPTION
`/creload` doesn't seem to reload channel data, and I expect the most common usage of it would be to test format changes in real time.

**Adds** a #clearAll method to IRegistry & child class CommandRegistry

**Refactors** channel load logic in ChannelManager into a new #reload method, and is prefixed by the aforementioned IRegistry#clearAll

**Still to look into** updating ACF with new channel aliases, should they be added/changed/removed.